### PR TITLE
Remove trailing ampersand, as it breaks some rets servers.

### DIFF
--- a/lib/rets/http.rb
+++ b/lib/rets/http.rb
@@ -218,6 +218,7 @@ module RETS
           args[:params].each do |k, v|
             request_uri << "#{k}=#{url_encode(v.to_s)}&" if v
           end
+          request_uri.gsub!(/&$/, '') # Remove trailing ampersand, breaks some RETS servers
         end
         request = Net::HTTP::Get.new request_uri, headers
       end

--- a/lib/rets/version.rb
+++ b/lib/rets/version.rb
@@ -1,3 +1,3 @@
 module RETS
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
This was necessary to get trestle to work.

@DubHunt do you see anything glaringly wrong with this?

I did a version bump as well.