### PR TITLE
Use present? to check for config values

### DIFF
--- a/lib/rets/http.rb
+++ b/lib/rets/http.rb
@@ -13,11 +13,11 @@ module RETS
       @config = {:http => {}, :proxy => {}}.merge(args)
       @rets_data, @cookie_list = {}, {}
 
-      if @config[:useragent] and @config[:useragent][:name]
+      if @config[:useragent] and @config[:useragent][:name] and @config[:useragent][:name] != ''
         @headers["User-Agent"] = @config[:useragent][:name]
       end
 
-      if @config[:rets_version]
+      if @config[:rets_version] and @config[:rets_version] != ''
         @rets_data[:version] = @config[:rets_version]
         self.setup_ua_authorization(:version => @config[:rets_version])
       end


### PR DESCRIPTION
This fixes https://firepoint.atlassian.net/browse/FIR-2777

See the commit message for a detailed description of what I did.

Here's a visual description:
![rets-sucks](https://user-images.githubusercontent.com/866866/42650613-183a82a0-85ca-11e8-96a5-05f8d1e8bfc2.gif)

This should fix the User-Agent issue that the MLS team is seeing. However, I'm wondering: how did this start happening? Did we change our Ruby version or something? Krystal says the last time it *didn't* happen was on July 5th.

Also, to update this gem in the RETS browser and CRM, do we just re-deploy those? It looks like the Gemfile is just fetching off master: `gem 'ruby-rets', :github => 'firepoint/ruby-rets'`